### PR TITLE
Confirm Term Start and End Dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ You should see the following message telling you have started the project succes
 Task Bot is up and running!
 ```
 
+You will need to have a local instance of MongoDB running in order to handle the data:
+
+In one tab in your terminal run:
+```bash
+mongod
+```
+
+In another tab run:
+```bash
+mongo task_bot
+```
+This is the name of the database for this project.
+
+#### Generation Scripts
+There is some data that needs to be present in the database to ensure that future manipulation works.
+Go to `app/scripts` to find all the data generation scripts necessary in order to interact with the bot fully.
+
 ## Commands 💪🏾
 There are a list of commands that the task bot will recognize by **direct messages** - you must be in DM channel for the bot to respond
 

--- a/app/data-actions/channel-productivity.js
+++ b/app/data-actions/channel-productivity.js
@@ -1,4 +1,3 @@
-import moment from 'moment'
 /*
  * Returns a productivity score for each provided channel
  * Current favors channels that have response times below

--- a/app/data-actions/markdown.js
+++ b/app/data-actions/markdown.js
@@ -1,0 +1,29 @@
+/*
+ * Takes a given header, makes it bold, all uppercase, and adds a
+ * newline character at the ned of it.
+ */
+export const formatHeader = (key) => {
+  return `\n*${key.toUpperCase()}*:\n`
+}
+
+/*
+ * Format items in a dictionary into a bullet list format where each
+ * line is tabbed.
+ */
+export const formatDicts = (dict) => {
+  let result = ''
+
+  for (const item in dict) {
+    result += `\t• ${dict[item]}\n`
+  }
+  return result
+}
+
+export const formatLists = (list) => {
+  let result = ''
+
+  list.forEach(item => {
+    result += `• ${item}\n`
+  })
+  return result
+}

--- a/app/data-actions/markdown.js
+++ b/app/data-actions/markdown.js
@@ -19,6 +19,10 @@ export const formatDicts = (dict) => {
   return result
 }
 
+/*
+ * Format items in a list into a bullet list format where each
+ * line is not tabbed.
+ */
 export const formatLists = (list) => {
   let result = ''
 

--- a/app/data-actions/milestones.js
+++ b/app/data-actions/milestones.js
@@ -1,103 +1,5 @@
-import moment from 'moment'
 import data from './../../mock_data/milestones'
-
-/*
- * Shifts the provided date to the first Wednesday
- */
-const shiftToWednesday = (termStartDate) => {
-  while (termStartDate.format('dddd') !== 'Wednesday') {
-    termStartDate.add(1, 'days')
-  }
-  return termStartDate
-}
-
-// Winter term ranges
-const firstWeekWinter = moment().week(1)
-let firstDayWinter = firstWeekWinter.add(2, 'days')
-let lastDayWinter = moment()
-while (firstDayWinter.format('dddd') !== 'Monday' && firstDayWinter.format('dddd') !== 'Wednesday') {
-  firstDayWinter.add(1, 'days')
-}
-firstDayWinter = shiftToWednesday(firstDayWinter)
-lastDayWinter = firstDayWinter.clone().add(10, 'weeks')
-console.log('First day of winter term:', firstDayWinter)
-console.log('Last day of winter term:', lastDayWinter)
-
-// Spring term ranges
-const firstWeekSpring = moment().week(13)
-let firstDaySpring = firstWeekSpring
-let lastDaySpring = moment()
-while (firstDaySpring.format('dddd') !== 'Monday') {
-  firstDaySpring.add(1, 'days')
-}
-firstDaySpring = shiftToWednesday(firstDaySpring)
-lastDaySpring = firstDaySpring.clone().add(10, 'weeks')
-console.log('First day of spring term:', firstDaySpring)
-console.log('Last day of winter term:', lastDaySpring)
-
-// Summer term ranges
-const firstWeekSummer = moment().week(24)
-let firstDaySummer = firstWeekSummer
-let lastDaySummer = moment()
-while (firstDaySummer.format('dddd') !== 'Thursday') {
-  firstDaySummer.add(1, 'days')
-}
-firstDaySummer = shiftToWednesday(firstDaySummer)
-lastDaySummer = firstDaySummer.clone().add(10, 'weeks')
-console.log('First day of summer term:', firstDaySummer)
-console.log('Last day of summer term:', lastDaySummer)
-
-// Fall term ranges
-const firstWeekFall = moment().week(36)
-let firstDayFall = firstWeekFall
-let lastDayFall = moment()
-while ((firstDayFall.format('dddd') !== 'Monday' && firstDayFall.format('dddd') !== 'Wednesday') || firstDayFall.get('date') < 11) {
-  firstDayFall.add(1, 'days')
-}
-firstDayFall = shiftToWednesday(firstDayFall)
-lastDayFall = firstDayFall.clone().add(10, 'weeks')
-console.log('First day of summer term:', firstDayFall)
-console.log('Last day of summer term:', lastDayFall)
-
-/*
- * Checks to see if the current date is in
- * one of the slated term ranges
- */
-export const checkOnTerm = () => {
-  const terms = [
-    { term: 'winter', ranges: [firstDayWinter, lastDayWinter] },
-    { term: 'spring', ranges: [firstDaySpring, lastDaySpring] },
-    { term: 'summer', ranges: [firstDaySummer, lastDaySummer] },
-    { term: 'fall', ranges: [firstDayFall, firstDayFall] },
-  ]
-  terms.forEach(currentTerm => {
-    if (moment().range(currentTerm.ranges[0], currentTerm.ranges[1]).contains(moment())) {
-      return { term: currentTerm.term, onTerm: true }
-    }
-  })
-  return { term: null, onTerm: false }
-}
-
-/*
- * Takes a given header, makes it bold, all uppercase, and adds a
- * newline character at the ned of it.
- */
-const formatHeader = (key) => {
-  return `\n*${key.toUpperCase()}*:\n`
-}
-
-/*
- * Format items in a dictionary into a bullet list format where each
- * line is tabbed.
- */
-const formatLists = (dict) => {
-  let result = ''
-
-  for (const item in dict) {
-    result += `\t• ${dict[item]}\n`
-  }
-  return result
-}
+import { formatHeader, formatDicts } from './markdown'
 
 /*
 * getMilestone() takes in the current week number and gets and formats the milestone for
@@ -115,7 +17,7 @@ export const getMilestone = (week) => {
     if (section !== 'milestone' && section !== 'title') {
       milestone += formatHeader(section)
       if (typeof rawMilestone[section] === typeof new Object()) {
-        milestone += formatLists(rawMilestone[section])
+        milestone += formatDicts(rawMilestone[section])
       } else {
         milestone += (`${rawMilestone[section]}\n`)
       }
@@ -126,18 +28,4 @@ export const getMilestone = (week) => {
   milestone += '\nBut wait, there\'s more! Check out https://build.dali.dartmouth.edu for the full list of tasks.'
 
   return milestone
-}
-
-/*
- * Returns the start date of a specified term
- * @param term - String representation of term
- */
-export const getTermStartDate = (term) => {
-  const termStartDates = {
-    winter: firstDayWinter,
-    spring: firstDaySpring,
-    summer: firstDaySummer,
-    fall: firstDayFall,
-  }
-  return termStartDates[term]
 }

--- a/app/data-actions/milestones.js
+++ b/app/data-actions/milestones.js
@@ -13,27 +13,27 @@ const shiftToWednesday = (termStartDate) => {
 
 // Winter term ranges
 const firstWeekWinter = moment().week(1)
-let firstDayWinter = firstWeekWinter.add(3 - firstWeekWinter.get('date'), 'days')
+let firstDayWinter = firstWeekWinter.add(2, 'days')
 let lastDayWinter = moment()
 while (firstDayWinter.format('dddd') !== 'Monday' && firstDayWinter.format('dddd') !== 'Wednesday') {
   firstDayWinter.add(1, 'days')
 }
 firstDayWinter = shiftToWednesday(firstDayWinter)
-lastDayWinter = firstDayWinter.add(10, 'weeks')
-console.log(`First day of winter term: ${firstDayWinter}`)
-console.log(`Last day of winter term: ${lastDayWinter}`)
+lastDayWinter = firstDayWinter.clone().add(10, 'weeks')
+console.log('First day of winter term:', firstDayWinter)
+console.log('Last day of winter term:', lastDayWinter)
 
 // Spring term ranges
-const firstWeekSpring = moment().week(12)
+const firstWeekSpring = moment().week(13)
 let firstDaySpring = firstWeekSpring
 let lastDaySpring = moment()
 while (firstDaySpring.format('dddd') !== 'Monday') {
   firstDaySpring.add(1, 'days')
 }
 firstDaySpring = shiftToWednesday(firstDaySpring)
-lastDaySpring = firstDaySpring.add(10, 'weeks')
-console.log(`First day of spring term: ${firstDaySpring}`)
-console.log(`Last day of winter term: ${lastDaySpring}`)
+lastDaySpring = firstDaySpring.clone().add(10, 'weeks')
+console.log('First day of spring term:', firstDaySpring)
+console.log('Last day of winter term:', lastDaySpring)
 
 // Summer term ranges
 const firstWeekSummer = moment().week(24)
@@ -43,9 +43,9 @@ while (firstDaySummer.format('dddd') !== 'Thursday') {
   firstDaySummer.add(1, 'days')
 }
 firstDaySummer = shiftToWednesday(firstDaySummer)
-lastDaySummer = firstDaySummer.add(10, 'weeks')
-console.log(`First day of summer term: ${firstDaySummer}`)
-console.log(`Last day of summer term: ${lastDaySummer}`)
+lastDaySummer = firstDaySummer.clone().add(10, 'weeks')
+console.log('First day of summer term:', firstDaySummer)
+console.log('Last day of summer term:', lastDaySummer)
 
 // Fall term ranges
 const firstWeekFall = moment().week(36)
@@ -55,27 +55,27 @@ while ((firstDayFall.format('dddd') !== 'Monday' && firstDayFall.format('dddd') 
   firstDayFall.add(1, 'days')
 }
 firstDayFall = shiftToWednesday(firstDayFall)
-lastDayFall = firstDayFall.add(10, 'weeks')
-console.log(`First day of summer term: ${firstDayFall}`)
-console.log(`Last day of summer term: ${lastDayFall}`)
+lastDayFall = firstDayFall.clone().add(10, 'weeks')
+console.log('First day of summer term:', firstDayFall)
+console.log('Last day of summer term:', lastDayFall)
 
 /*
  * Checks to see if the current date is in
  * one of the slated term ranges
  */
 export const checkOnTerm = () => {
-  const ranges = [
-    [firstDayWinter, lastDayWinter],
-    [firstDaySpring, lastDaySpring],
-    [firstDaySummer, lastDaySummer],
-    [firstDayFall, firstDayFall],
+  const terms = [
+    { term: 'winter', ranges: [firstDayWinter, lastDayWinter] },
+    { term: 'spring', ranges: [firstDaySpring, lastDaySpring] },
+    { term: 'summer', ranges: [firstDaySummer, lastDaySummer] },
+    { term: 'fall', ranges: [firstDayFall, firstDayFall] },
   ]
-  ranges.forEach(currentRange => {
-    if (moment().range(currentRange[0], currentRange[1]).contains(moment())) {
-      return true
+  terms.forEach(currentTerm => {
+    if (moment().range(currentTerm.ranges[0], currentTerm.ranges[1]).contains(moment())) {
+      return { term: currentTerm.term, onTerm: true }
     }
   })
-  return false
+  return { term: null, onTerm: false }
 }
 
 /*
@@ -126,4 +126,18 @@ export const getMilestone = (week) => {
   milestone += '\nBut wait, there\'s more! Check out https://build.dali.dartmouth.edu for the full list of tasks.'
 
   return milestone
+}
+
+/*
+ * Returns the start date of a specified term
+ * @param term - String representation of term
+ */
+export const getTermStartDate = (term) => {
+  const termStartDates = {
+    winter: firstDayWinter,
+    spring: firstDaySpring,
+    summer: firstDaySummer,
+    fall: firstDayFall,
+  }
+  return termStartDates[term]
 }

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -117,21 +117,6 @@ export const getUpdatedDates = () => {
   return [newStartDate, newEndDate]
 }
 
-/*
- * Returns the start date of a specified term
- * @param term - String representation of term
- */
-export const getTermStartDate = (term) => {
-  return new Promise((resolve, reject) => {
-    getTerm(term)
-      .exec((err, res) => {
-        if (err) reject(err)
-        console.log(res.startDate)
-        resolve(res.startDate)
-      })
-  })
-}
-
 let confirmDatesMessage = {
   introMessage: '\nHey! I wanted to check to see if my start date for the upcoming term is correct!\n',
   introCurrentDates: 'I currently have the following dates:\n\n',
@@ -151,11 +136,10 @@ export const getConfirmDatesMessage = (currentTerm) => {
   let startDate = null
   let endDate = null
   return new Promise((resolve, reject) => {
-    getTermStartDate(currentTerm)
-      .then(resStart => {
-        console.log(resStart)
-        startDate = moment(resStart)
-        endDate = moment(resStart).clone().add(10, 'weeks')
+    getTerm(currentTerm)
+      .then(term => {
+        startDate = moment(term.startDate)
+        endDate = moment(term.endDate)
         for (const section in confirmDatesMessage) {
           if (section !== 'dates' && section !== 'commands') {
             message += confirmDatesMessage[section]

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import { formatLists } from './markdown'
+import { getTerm } from './../db-actions/term-actions'
 
 /*
  * Shifts the provided date to the first Wednesday
@@ -101,32 +102,26 @@ export const daysBeforeStart = (termStartDates) => {
  * @param term - String representation of term
  */
 export const getTermStartDate = (term) => {
-  const termStartDates = generateTermDates()
-  let correctRange = null
-  termStartDates.forEach(currentTerm => {
-    if (currentTerm.term === term) {
-      correctRange = currentTerm.ranges[0]
-    }
-  })
-  return correctRange
+  const currentTerm = getTerm(term)
+  return currentTerm.startDate
 }
 
-let confirmDatesMessage = {
-  introMessage: '\nHey! I wanted to check to see if my start date for the upcoming term is correct!\n',
-  introCurrentDates: 'I currently have the following dates:\n\n',
-  dates: [
-    `Start date - ${getTermStartDate('spring').format('dddd, MMMM Do YYYY')}`,
-    `End date - ${getTermStartDate('spring').add(10, 'weeks').format('dddd, MMMM Do YYYY')}`,
-  ],
-  introCommands: '\nHere is a list of commands that should be used:\n\n',
-  commands: [
-    '*update_start MM-DD-YYYY* - updates the start date. i.e. 09-10-2018',
-    '*update_end MM-DD-YYYY* - updates the end date',
-    '*show* - shows the updated dates',
-    '*abort* - ends confirmation and will be reminded tomorrow at 10AM',
-    '*complete* - completes confirmation',
-  ],
-}
+// let confirmDatesMessage = {
+//   introMessage: '\nHey! I wanted to check to see if my start date for the upcoming term is correct!\n',
+//   introCurrentDates: 'I currently have the following dates:\n\n',
+//   dates: [
+//     `Start date - ${getTermStartDate('spring').format('dddd, MMMM Do YYYY')}`,
+//     `End date - ${getTermStartDate('spring').add(10, 'weeks').format('dddd, MMMM Do YYYY')}`,
+//   ],
+//   introCommands: '\nHere is a list of commands that should be used:\n\n',
+//   commands: [
+//     '*update_start MM-DD-YYYY* - updates the start date. i.e. 09-10-2018',
+//     '*update_end MM-DD-YYYY* - updates the end date',
+//     '*show* - shows the updated dates',
+//     '*abort* - ends confirmation and will be reminded tomorrow at 10AM',
+//     '*complete* - completes confirmation',
+//   ],
+// }
 
 export const getConfirmDatesMessage = () => {
   let message = ''

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -105,15 +105,15 @@ export const checkOnTerm = (terms) => {
  */
 export const daysBeforeStart = (terms) => {
   let minDays = 10000
-  let currentTerm = null
+  let upcomingTerm = null
   terms.forEach(term => {
     const daysDifference = Math.abs(moment().diff(term.ranges[0], 'days'))
     if (minDays > daysDifference) {
       minDays = daysDifference
-      currentTerm = term.term
+      upcomingTerm = term.term
     }
   })
-  return { daysBefore: minDays, currentTerm }
+  return { daysBefore: minDays, upcomingTerm }
 }
 
 export const updateStartDate = (date) => {

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -101,11 +101,11 @@ export const daysBeforeStart = (termStartDates) => {
 }
 
 export const updateStartDate = (date) => {
-  newStartDate = date.format('dddd, MMMM Do YYYY')
+  newStartDate = date
 }
 
 export const updateEndDate = (date) => {
-  newEndDate = date.format('dddd, MMMM Do YYYY')
+  newEndDate = date
 }
 
 /*
@@ -146,16 +146,16 @@ let confirmDatesMessage = {
   ],
 }
 
-export const getConfirmDatesMessage = () => {
+export const getConfirmDatesMessage = (currentTerm) => {
   let message = ''
   let startDate = null
   let endDate = null
   return new Promise((resolve, reject) => {
-    getTermStartDate('spring')
+    getTermStartDate(currentTerm)
       .then(resStart => {
         console.log(resStart)
-        startDate = moment(resStart).format('dddd, MMMM Do YYYY')
-        endDate = moment(resStart).clone().add(10, 'weeks').format('dddd, MMMM Do YYYY')
+        startDate = moment(resStart)
+        endDate = moment(resStart).clone().add(10, 'weeks')
         for (const section in confirmDatesMessage) {
           if (section !== 'dates' && section !== 'commands') {
             message += confirmDatesMessage[section]
@@ -164,8 +164,8 @@ export const getConfirmDatesMessage = () => {
               newStartDate = startDate
               newEndDate = endDate
               confirmDatesMessage[section] = [
-                `Start date - ${startDate}`,
-                `End date - ${endDate}`,
+                `Start date - ${startDate.format('dddd, MMMM Do YYYY')}`,
+                `End date - ${endDate.format('dddd, MMMM Do YYYY')}`,
               ]
             }
             message += formatLists(confirmDatesMessage[section])

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -115,6 +115,7 @@ export const checkOnTerm = (terms) => {
 export const daysBeforeStart = (terms) => {
   let minDays = 10000
   let upcomingTerm = null
+  // finding the term that has the smallest difference in days
   terms.forEach(term => {
     const daysDifference = Math.abs(moment().diff(term.ranges[0], 'days'))
     if (minDays > daysDifference) {
@@ -181,9 +182,11 @@ export const getConfirmDatesMessage = (currentTerm) => {
         endDate = moment(term.endDate)
         for (const section in confirmDatesMessage) {
           if (section !== 'dates' && section !== 'commands') {
+            // if not a list, handle as regular text
             message += confirmDatesMessage[section]
           } else {
             if (section === 'dates') {
+              // populating the start/end dates with dates from database
               newStartDate = startDate
               newEndDate = endDate
               confirmDatesMessage[section] = [

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import { formatLists } from './markdown'
-import { getTerm, getTerms} from './../db-actions/term-actions'
+import { getTerm, getTerms } from './../db-actions/term-actions'
 
 let newStartDate
 let newEndDate
@@ -15,6 +15,11 @@ const shiftToWednesday = (termStartDate) => {
   return termStartDate
 }
 
+/*
+ * Generates possible term start and end dates
+ * for all terms. Once generated, the terms will
+ * then be presented to admin user to confirm
+ */
 export const generateTermDates = () => {
   // Winter term ranges
   const firstWeekWinter = moment().week(1)
@@ -74,6 +79,10 @@ export const generateTermDates = () => {
   return terms
 }
 
+/*
+ * Grabs from database and creates a list that holds
+ * the term name and the start/end dates
+ */
 export const termDates = () => {
   const terms = []
   return new Promise((resolve, reject) => {
@@ -116,10 +125,16 @@ export const daysBeforeStart = (terms) => {
   return { daysBefore: minDays, upcomingTerm }
 }
 
+/*
+ * Updates the local newStartDate variable
+ */
 export const updateStartDate = (date) => {
   newStartDate = date
 }
 
+/*
+ * Updates the local newEndDate variable
+ */
 export const updateEndDate = (date) => {
   newEndDate = date
 }
@@ -133,7 +148,11 @@ export const getUpdatedDates = () => {
   return [newStartDate, newEndDate]
 }
 
-let confirmDatesMessage = {
+/*
+ * Confirmation message that will be sent out to
+ * admin user to begin updating term dates
+ */
+const confirmDatesMessage = {
   introMessage: '\nHey! I wanted to check to see if my start date for the upcoming term is correct!\n',
   introCurrentDates: 'I currently have the following dates:\n\n',
   dates: [],
@@ -147,6 +166,10 @@ let confirmDatesMessage = {
   ],
 }
 
+/*
+ * Works with the confirmDatesMessage object to populate the
+ * blank dates section. Grabs information from database
+ */
 export const getConfirmDatesMessage = (currentTerm) => {
   let message = ''
   let startDate = null

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -11,65 +11,70 @@ const shiftToWednesday = (termStartDate) => {
   return termStartDate
 }
 
-// Winter term ranges
-const firstWeekWinter = moment().week(1)
-let firstDayWinter = firstWeekWinter.add(2, 'days')
-let lastDayWinter = moment()
-while (firstDayWinter.format('dddd') !== 'Monday' && firstDayWinter.format('dddd') !== 'Wednesday') {
-  firstDayWinter.add(1, 'days')
-}
-firstDayWinter = shiftToWednesday(firstDayWinter)
-lastDayWinter = firstDayWinter.clone().add(10, 'weeks')
-console.log('First day of winter term:', firstDayWinter)
-console.log('Last day of winter term:', lastDayWinter)
+export const generateTermDates = () => {
+  // Winter term ranges
+  const firstWeekWinter = moment().week(1)
+  let firstDayWinter = firstWeekWinter.add(2, 'days')
+  let lastDayWinter = moment()
+  while (firstDayWinter.format('dddd') !== 'Monday' && firstDayWinter.format('dddd') !== 'Wednesday') {
+    firstDayWinter.add(1, 'days')
+  }
+  firstDayWinter = shiftToWednesday(firstDayWinter)
+  lastDayWinter = firstDayWinter.clone().add(10, 'weeks')
+  console.log('First day of winter term:', firstDayWinter)
+  console.log('Last day of winter term:', lastDayWinter)
 
-// Spring term ranges
-const firstWeekSpring = moment().week(13)
-let firstDaySpring = firstWeekSpring
-let lastDaySpring = moment()
-while (firstDaySpring.format('dddd') !== 'Monday') {
-  firstDaySpring.add(1, 'days')
-}
-firstDaySpring = shiftToWednesday(firstDaySpring)
-lastDaySpring = firstDaySpring.clone().add(10, 'weeks')
-console.log('First day of spring term:', firstDaySpring)
-console.log('Last day of winter term:', lastDaySpring)
+  // Spring term ranges
+  const firstWeekSpring = moment().week(13)
+  let firstDaySpring = firstWeekSpring
+  let lastDaySpring = moment()
+  while (firstDaySpring.format('dddd') !== 'Monday') {
+    firstDaySpring.add(1, 'days')
+  }
+  firstDaySpring = shiftToWednesday(firstDaySpring)
+  lastDaySpring = firstDaySpring.clone().add(10, 'weeks')
+  console.log('First day of spring term:', firstDaySpring)
+  console.log('Last day of winter term:', lastDaySpring)
 
-// Summer term ranges
-const firstWeekSummer = moment().week(24)
-let firstDaySummer = firstWeekSummer
-let lastDaySummer = moment()
-while (firstDaySummer.format('dddd') !== 'Thursday') {
-  firstDaySummer.add(1, 'days')
-}
-firstDaySummer = shiftToWednesday(firstDaySummer)
-lastDaySummer = firstDaySummer.clone().add(10, 'weeks')
-console.log('First day of summer term:', firstDaySummer)
-console.log('Last day of summer term:', lastDaySummer)
+  // Summer term ranges
+  const firstWeekSummer = moment().week(24)
+  let firstDaySummer = firstWeekSummer
+  let lastDaySummer = moment()
+  while (firstDaySummer.format('dddd') !== 'Thursday') {
+    firstDaySummer.add(1, 'days')
+  }
+  firstDaySummer = shiftToWednesday(firstDaySummer)
+  lastDaySummer = firstDaySummer.clone().add(10, 'weeks')
+  console.log('First day of summer term:', firstDaySummer)
+  console.log('Last day of summer term:', lastDaySummer)
 
-// Fall term ranges
-const firstWeekFall = moment().week(36)
-let firstDayFall = firstWeekFall
-let lastDayFall = moment()
-while ((firstDayFall.format('dddd') !== 'Monday' && firstDayFall.format('dddd') !== 'Wednesday') || firstDayFall.get('date') < 11) {
-  firstDayFall.add(1, 'days')
-}
-firstDayFall = shiftToWednesday(firstDayFall)
-lastDayFall = firstDayFall.clone().add(10, 'weeks')
-console.log('First day of summer term:', firstDayFall)
-console.log('Last day of summer term:', lastDayFall)
+  // Fall term ranges
+  const firstWeekFall = moment().week(36)
+  let firstDayFall = firstWeekFall
+  let lastDayFall = moment()
+  while ((firstDayFall.format('dddd') !== 'Monday' && firstDayFall.format('dddd') !== 'Wednesday') || firstDayFall.get('date') < 11) {
+    firstDayFall.add(1, 'days')
+  }
+  firstDayFall = shiftToWednesday(firstDayFall)
+  lastDayFall = firstDayFall.clone().add(10, 'weeks')
+  console.log('First day of summer term:', firstDayFall)
+  console.log('Last day of summer term:', lastDayFall)
 
-/*
- * Checks to see if the current date is in
- * one of the slated term ranges
- */
-export const checkOnTerm = () => {
   const terms = [
     { term: 'winter', ranges: [firstDayWinter, lastDayWinter] },
     { term: 'spring', ranges: [firstDaySpring, lastDaySpring] },
     { term: 'summer', ranges: [firstDaySummer, lastDaySummer] },
     { term: 'fall', ranges: [firstDayFall, firstDayFall] },
   ]
+
+  return terms
+}
+
+/*
+ * Checks to see if the current date is in
+ * one of the slated term ranges
+ */
+export const checkOnTerm = (terms) => {
   terms.forEach(currentTerm => {
     if (moment().range(currentTerm.ranges[0], currentTerm.ranges[1]).contains(moment())) {
       return { term: currentTerm.term, onTerm: true }
@@ -81,8 +86,8 @@ export const checkOnTerm = () => {
 /*
  * Calculates the days before the start of upcoming term
  */
-export const daysBeforeStart = () => {
-  const startDates = [firstDayWinter, firstDaySpring, firstDaySummer, firstDayFall]
+export const daysBeforeStart = (termStartDates) => {
+  const startDates = termStartDates
   let minDays = 10000
   startDates.forEach(startDate => {
     minDays = Math.min(minDays, Math.abs(moment().diff(startDate, 'days')))
@@ -96,13 +101,14 @@ export const daysBeforeStart = () => {
  * @param term - String representation of term
  */
 export const getTermStartDate = (term) => {
-  const termStartDates = {
-    winter: firstDayWinter,
-    spring: firstDaySpring,
-    summer: firstDaySummer,
-    fall: firstDayFall,
-  }
-  return termStartDates[term]
+  const termStartDates = generateTermDates()
+  let correctRange = null
+  termStartDates.forEach(currentTerm => {
+    if (currentTerm.term === term) {
+      correctRange = currentTerm.ranges[0]
+    }
+  })
+  return correctRange
 }
 
 let confirmDatesMessage = {

--- a/app/data-actions/term-dates.js
+++ b/app/data-actions/term-dates.js
@@ -1,0 +1,135 @@
+import moment from 'moment'
+import { formatLists } from './markdown'
+
+/*
+ * Shifts the provided date to the first Wednesday
+ */
+const shiftToWednesday = (termStartDate) => {
+  while (termStartDate.format('dddd') !== 'Wednesday') {
+    termStartDate.add(1, 'days')
+  }
+  return termStartDate
+}
+
+// Winter term ranges
+const firstWeekWinter = moment().week(1)
+let firstDayWinter = firstWeekWinter.add(2, 'days')
+let lastDayWinter = moment()
+while (firstDayWinter.format('dddd') !== 'Monday' && firstDayWinter.format('dddd') !== 'Wednesday') {
+  firstDayWinter.add(1, 'days')
+}
+firstDayWinter = shiftToWednesday(firstDayWinter)
+lastDayWinter = firstDayWinter.clone().add(10, 'weeks')
+console.log('First day of winter term:', firstDayWinter)
+console.log('Last day of winter term:', lastDayWinter)
+
+// Spring term ranges
+const firstWeekSpring = moment().week(13)
+let firstDaySpring = firstWeekSpring
+let lastDaySpring = moment()
+while (firstDaySpring.format('dddd') !== 'Monday') {
+  firstDaySpring.add(1, 'days')
+}
+firstDaySpring = shiftToWednesday(firstDaySpring)
+lastDaySpring = firstDaySpring.clone().add(10, 'weeks')
+console.log('First day of spring term:', firstDaySpring)
+console.log('Last day of winter term:', lastDaySpring)
+
+// Summer term ranges
+const firstWeekSummer = moment().week(24)
+let firstDaySummer = firstWeekSummer
+let lastDaySummer = moment()
+while (firstDaySummer.format('dddd') !== 'Thursday') {
+  firstDaySummer.add(1, 'days')
+}
+firstDaySummer = shiftToWednesday(firstDaySummer)
+lastDaySummer = firstDaySummer.clone().add(10, 'weeks')
+console.log('First day of summer term:', firstDaySummer)
+console.log('Last day of summer term:', lastDaySummer)
+
+// Fall term ranges
+const firstWeekFall = moment().week(36)
+let firstDayFall = firstWeekFall
+let lastDayFall = moment()
+while ((firstDayFall.format('dddd') !== 'Monday' && firstDayFall.format('dddd') !== 'Wednesday') || firstDayFall.get('date') < 11) {
+  firstDayFall.add(1, 'days')
+}
+firstDayFall = shiftToWednesday(firstDayFall)
+lastDayFall = firstDayFall.clone().add(10, 'weeks')
+console.log('First day of summer term:', firstDayFall)
+console.log('Last day of summer term:', lastDayFall)
+
+/*
+ * Checks to see if the current date is in
+ * one of the slated term ranges
+ */
+export const checkOnTerm = () => {
+  const terms = [
+    { term: 'winter', ranges: [firstDayWinter, lastDayWinter] },
+    { term: 'spring', ranges: [firstDaySpring, lastDaySpring] },
+    { term: 'summer', ranges: [firstDaySummer, lastDaySummer] },
+    { term: 'fall', ranges: [firstDayFall, firstDayFall] },
+  ]
+  terms.forEach(currentTerm => {
+    if (moment().range(currentTerm.ranges[0], currentTerm.ranges[1]).contains(moment())) {
+      return { term: currentTerm.term, onTerm: true }
+    }
+  })
+  return { term: null, onTerm: false }
+}
+
+/*
+ * Calculates the days before the start of upcoming term
+ */
+export const daysBeforeStart = () => {
+  const startDates = [firstDayWinter, firstDaySpring, firstDaySummer, firstDayFall]
+  let minDays = 10000
+  startDates.forEach(startDate => {
+    minDays = Math.min(minDays, Math.abs(moment().diff(startDate, 'days')))
+  })
+  console.log(`Days before the next term starts: ${minDays}`)
+  return minDays
+}
+
+/*
+ * Returns the start date of a specified term
+ * @param term - String representation of term
+ */
+export const getTermStartDate = (term) => {
+  const termStartDates = {
+    winter: firstDayWinter,
+    spring: firstDaySpring,
+    summer: firstDaySummer,
+    fall: firstDayFall,
+  }
+  return termStartDates[term]
+}
+
+let confirmDatesMessage = {
+  introMessage: '\nHey! I wanted to check to see if my start date for the upcoming term is correct!\n',
+  introCurrentDates: 'I currently have the following dates:\n\n',
+  dates: [
+    `Start date - ${getTermStartDate('spring').format('dddd, MMMM Do YYYY')}`,
+    `End date - ${getTermStartDate('spring').add(10, 'weeks').format('dddd, MMMM Do YYYY')}`,
+  ],
+  introCommands: '\nHere is a list of commands that should be used:\n\n',
+  commands: [
+    '*update_start MM-DD-YYYY* - updates the start date. i.e. 09-10-2018',
+    '*update_end MM-DD-YYYY* - updates the end date',
+    '*show* - shows the updated dates',
+    '*abort* - ends confirmation and will be reminded tomorrow at 10AM',
+    '*complete* - completes confirmation',
+  ],
+}
+
+export const getConfirmDatesMessage = () => {
+  let message = ''
+  for (const section in confirmDatesMessage) {
+    if (section !== 'dates' && section !== 'commands') {
+      message += confirmDatesMessage[section]
+    } else {
+      message += formatLists(confirmDatesMessage[section])
+    }
+  }
+  return message
+}

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import Term from './../models/term'
 
 export function createTerm(data) {
@@ -7,5 +6,25 @@ export function createTerm(data) {
   newTerm.save((err, res) => {
     if (err) return err
     console.log(`POST new term ${termData.name}`)
+  })
+}
+
+export function updateTerm(data) {
+  Term.update(
+    { name: data.name },
+    { $set: { startDate: data.startDate, endDate: data.endDate } }
+  )
+  .then((err, res) => {
+    if (err) return err
+    console.log(`Successfully updated the term ${data.name}`)
+  })
+}
+
+export function getTerm(termName) {
+  Term.find({ name: termName })
+  .then((err, res) => {
+    if (err) return err
+    console.log(`Successfully got the term ${termName}`)
+    return res
   })
 }

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -10,20 +10,18 @@ export function createTerm(data) {
 }
 
 export function updateTerm(data) {
-  Term.update(
-    { name: data.name },
-    { $set: { startDate: data.startDate, endDate: data.endDate } }
-  )
-  .exec((err, res) => {
-    if (err) return err
-    console.log(`Successfully updated the term ${data.name}`)
+  return new Promise((resolve, reject) => {
+    Term.update(
+      { name: data.name },
+      { $set: { startDate: data.startDate, endDate: data.endDate } }
+    )
+      .exec((err, res) => {
+        if (err) reject(err)
+        resolve(`Successfully updated the term ${data.name}`)
+      })
   })
 }
 
 export function getTerm(termName) {
   return Term.findOne({ name: termName })
-  // .exec((err, res) => {
-  //   if (err) return err
-  //   return res
-  // })
 }

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -1,0 +1,11 @@
+import fetch from 'node-fetch'
+import Term from './../models/term'
+
+export function createTerm(data) {
+  const termData = { id: data.id, name: data.name, startDate: data.startDate, endDate: data.endDate }
+  const newTerm = new Term(termData)
+  newTerm.save((err, res) => {
+    if (err) return err
+    console.log(`POST new term ${termData.name}`)
+  })
+}

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -14,17 +14,16 @@ export function updateTerm(data) {
     { name: data.name },
     { $set: { startDate: data.startDate, endDate: data.endDate } }
   )
-  .then((err, res) => {
+  .exec((err, res) => {
     if (err) return err
     console.log(`Successfully updated the term ${data.name}`)
   })
 }
 
 export function getTerm(termName) {
-  Term.find({ name: termName })
-  .then((err, res) => {
+  Term.findOne({ name: termName })
+  .exec((err, res) => {
     if (err) return err
-    console.log(`Successfully got the term ${termName}`)
     return res
   })
 }

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -1,7 +1,7 @@
 import Term from './../models/term'
 
 export function createTerm(data) {
-  const termData = { id: data.id, name: data.name, startDate: data.startDate, endDate: data.endDate }
+  const termData = { name: data.name, startDate: data.startDate, endDate: data.endDate }
   const newTerm = new Term(termData)
   newTerm.save((err, res) => {
     if (err) return err

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -1,5 +1,10 @@
 import Term from './../models/term'
 
+/*
+ * Creates a new Term model in the database.
+ * Used for populating database with initial
+ * information.
+ */
 export function createTerm(data) {
   const termData = { name: data.name, startDate: data.startDate, endDate: data.endDate }
   const newTerm = new Term(termData)
@@ -9,6 +14,10 @@ export function createTerm(data) {
   })
 }
 
+/*
+ * Updates the specified Term. The correct
+ * Term is found with the name property.
+ */
 export function updateTerm(data) {
   return new Promise((resolve, reject) => {
     Term.update(
@@ -22,10 +31,18 @@ export function updateTerm(data) {
   })
 }
 
+/*
+ * Gets a Term object from the database using
+ * the Term's name property.
+ */
 export function getTerm(termName) {
   return Term.findOne({ name: termName })
 }
 
-export function getTerm() {
+/*
+ * Gets all the Term objects currently existing
+ * in the local database.
+ */
+export function getTerms() {
   return Term.find({})
 }

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -25,3 +25,7 @@ export function updateTerm(data) {
 export function getTerm(termName) {
   return Term.findOne({ name: termName })
 }
+
+export function getTerm() {
+  return Term.find({})
+}

--- a/app/db-actions/term-actions.js
+++ b/app/db-actions/term-actions.js
@@ -21,9 +21,9 @@ export function updateTerm(data) {
 }
 
 export function getTerm(termName) {
-  Term.findOne({ name: termName })
-  .exec((err, res) => {
-    if (err) return err
-    return res
-  })
+  return Term.findOne({ name: termName })
+  // .exec((err, res) => {
+  //   if (err) return err
+  //   return res
+  // })
 }

--- a/app/db.js
+++ b/app/db.js
@@ -4,6 +4,8 @@ const database = 'mongodb://127.0.0.1/task_bot'
 mongoose.connect(database, (err, res) => {
   if (err) {
     console.log('There was an error connecting the database')
+  } else {
+    console.log('Connected to the database!')
   }
 })
 module.exports = mongoose.connection

--- a/app/models/term.js
+++ b/app/models/term.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose'
+const Schema = mongoose.Schema
+
+const termSchema = new Schema({
+  id: String,
+  name: String,
+  startDate: Date,
+  endDate: Date,
+})
+
+const term = mongoose.model('Term', termSchema)
+module.export = term

--- a/app/models/term.js
+++ b/app/models/term.js
@@ -2,11 +2,10 @@ import mongoose from 'mongoose'
 const Schema = mongoose.Schema
 
 const termSchema = new Schema({
-  id: String,
   name: String,
   startDate: Date,
   endDate: Date,
 })
 
 const term = mongoose.model('Term', termSchema)
-module.export = term
+module.exports = term

--- a/app/scripts/populate-terms.js
+++ b/app/scripts/populate-terms.js
@@ -1,0 +1,12 @@
+import * as db from './../db'
+import { generateTermDates } from './../data-actions/term-dates'
+import { createTerm } from './../db-actions/term-actions'
+
+// Populates the database with automatically generated term dates
+
+const terms = generateTermDates()
+
+terms.forEach(term => {
+  const termObject = { name: term.term, startDate: term.ranges[0], endDate: term.ranges[1] }
+  createTerm(termObject)
+})

--- a/app/server.js
+++ b/app/server.js
@@ -192,7 +192,7 @@ controller.hears(/(update_term_dates)\b/, ['direct_message'], (bot, message) => 
 /*
  * Adds all users into the database
  */
-controller.hears('add_all_users', ['direct_message'], (bot, message) => {
+controller.hears(/(add_all_users)\b/, ['direct_message'], (bot, message) => {
   bot.api.users.list({}, (err, res) => {
     if (err) return err
     res.members.forEach(member => {
@@ -208,7 +208,7 @@ controller.hears('add_all_users', ['direct_message'], (bot, message) => {
 /*
  * Grabs all users from DALI-API
  */
-controller.hears('get_dali_users', ['direct_message'], (bot, message) => {
+controller.hears(/(get_dali_users)\b/, ['direct_message'], (bot, message) => {
   getDALIUsers()
   .then(res => { return res.json() })
   .then(json => {
@@ -219,7 +219,7 @@ controller.hears('get_dali_users', ['direct_message'], (bot, message) => {
 /*
  * Adds a specified user
  */
-controller.hears('add_user', ['direct_message'], (bot, message) => {
+controller.hears(/(add_user)\b/, ['direct_message'], (bot, message) => {
   const newUser = message.text.split(/[ <>@]/).filter(item => item.length > 0)[1]
   bot.api.users.info({ user: newUser }, (err, res) => {
     createUser(res.user)

--- a/app/server.js
+++ b/app/server.js
@@ -3,7 +3,7 @@ import schedule from 'node-schedule'
 import moment from 'moment'
 import { createUser, getDALIUsers } from './db-actions/user-actions'
 import { pokeChannels, getPokeChannels } from './data-actions/channel-productivity'
-import { checkOnTerm, getTermStartDate, daysBeforeStart, getConfirmDatesMessage } from './data-actions/term-dates'
+import { checkOnTerm, getTermStartDate, daysBeforeStart, getConfirmDatesMessage, generateTermDates } from './data-actions/term-dates'
 import { getMilestone } from './data-actions/milestones'
 
 let currentWeek = 0
@@ -232,13 +232,16 @@ controller.trigger('send_term_start_confirmation', [slackbotRTM])
 const updateTermStart = schedule.scheduleJob({ hour: 10, minute: 0, second: 0 }, () => {
   console.log('Updating the term start date')
 
-  if (daysBeforeStart < 4 && !confirmedDate) {
-    // Start conversation with user to update term dates
-    // slackbot.startRTM((err, bot) => {
-    //   if (err) throw new Error(err)
-
-    //   console.log('Sending confirmation message to user')
-    //   controller.trigger('send_term_start_confirmation', [bot])
-    // })
+  if (!confirmedDate) {
+    const generatedTerms = generateTermDates()
+    const termStartDates = []
+    for (const term in generatedTerms) {
+      termStartDates.push(generatedTerms[term].ranges[0])
+    }
+    if (daysBeforeStart(termStartDates) < 4) {
+      // Start the conversation to confirm start dates
+    } else {
+      console.log(daysBeforeStart(termStartDates))
+    }
   }
 })

--- a/app/server.js
+++ b/app/server.js
@@ -11,7 +11,7 @@ import { getMilestone } from './data-actions/milestones'
 let currentWeek = 0
 let currentTerm = null
 let onTerm = false
-let confirmedDate = false
+let confirmedDates = false
 let updatingDates = getConfirmDatesMessage
 
 // botkit controller
@@ -152,6 +152,7 @@ controller.hears('show', ['direct_message'], (bot, message) => {
 
 controller.hears('abort', ['direct_message'], (bot, message) => {
   if (updatingDates) {
+    updatingDates = false
     bot.reply(message, 'Alright, I will check back in with you tomorrow at 10AM')
     const tomorrowAtTen = moment().add(1, 'days').hour(10).toDate()
     const confirmDatesTomorrow = schedule.scheduleJob(tomorrowAtTen, () => {
@@ -162,7 +163,9 @@ controller.hears('abort', ['direct_message'], (bot, message) => {
 
 controller.hears('complete', ['direct_message'], (bot, message) => {
   if (updatingDates) {
-    bot.reply(message, 'Sweet! Thanks for updating the dates!\n\nUse update_term_dates to update the upcoming term start and end')
+    updatingDates = false
+    confirmedDates = true
+    bot.reply(message, 'Sweet! Thanks for updating the dates!\n\nUse *update_term_dates* to update the upcoming term start and end')
   }
 })
 

--- a/app/server.js
+++ b/app/server.js
@@ -122,7 +122,7 @@ controller.on('send_term_start_confirmation', (bot) => {
       const directChannelId = res1.channel.id
       updatingDates = true
       // getConfirmDatesMessage(currentTerm)
-      getConfirmDatesMessage('spring')
+      getConfirmDatesMessage(currentTerm)
         .then(message => {
           bot.say({ channel: directChannelId, text: message }, () => { })
         })
@@ -271,9 +271,6 @@ const updateTermInfo = schedule.scheduleJob({ hour: 0, minute: 0, second: 0 }, (
   onTerm = termResults.onTerm
 })
 
-console.log('Sending confirmation message to user')
-controller.trigger('send_term_start_confirmation', [slackbotRTM])
-
 // Checks daily at 10AM to see whether the bot should update the start dates for the term
 const updateTermStart = schedule.scheduleJob({ hour: 10, minute: 0, second: 0 }, () => {
   console.log('Updating the term start date')
@@ -287,6 +284,8 @@ const updateTermStart = schedule.scheduleJob({ hour: 10, minute: 0, second: 0 },
       updatingDates = true
       confirmedDates = false
       // Start the conversation to confirm start dates
+      console.log('Sending confirmation message to user')
+      controller.trigger('send_term_start_confirmation', [slackbotRTM])
     } else {
       console.log(`Days before the upcoming term start: ${daysBefore}`)
     }

--- a/app/server.js
+++ b/app/server.js
@@ -253,10 +253,6 @@ const updateTermInfo = schedule.scheduleJob({ hour: 0, minute: 0, second: 0 }, (
   console.log('Updating the expected term bounds are correct')
 
   // We are not in a term and we haven't confirmed correct term start/end dates
-  /*
-   * TODO: Check with admin to make sure that currently assigned
-   * start/end dates are correct
-   */
   const termResults = checkOnTerm()
   currentTerm = termResults.term
   onTerm = termResults.onTerm

--- a/app/server.js
+++ b/app/server.js
@@ -273,7 +273,7 @@ const updateTermStart = schedule.scheduleJob({ hour: 10, minute: 0, second: 0 },
     // Checks to see if it is less than four days before the next term
     const pulledTerms = termDates()
     const daysBefore = daysBeforeStart(pulledTerms).daysBefore
-    currentTerm = daysBeforeStart(pulledTerms).daysBefore
+    currentTerm = daysBeforeStart(pulledTerms).upcomingTerm
     if (daysBefore < 4) {
       updatingDates = true
       confirmedDates = false

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,6 @@ import { createUser, getDALIUsers } from './db-actions/user-actions'
 import { pokeChannels, getPokeChannels } from './data-actions/channel-productivity'
 import { 
   checkOnTerm,
-  getTermStartDate,
   daysBeforeStart,
   getConfirmDatesMessage,
   generateTermDates,
@@ -15,7 +14,7 @@ import {
   updateEndDate,
   getUpdatedDates,
 } from './data-actions/term-dates'
-import { updateTerm } from './db-actions/term-actions'
+import { updateTerm, getTerm } from './db-actions/term-actions'
 import { getMilestone } from './data-actions/milestones'
 
 let currentWeek = 0
@@ -148,15 +147,13 @@ controller.hears('update_end', ['direct_message'], (bot, message) => {
 
 controller.hears('show', ['direct_message'], (bot, message) => {
   if (updatingDates) {
-    getTermStartDate('spring').then(date => {
-      const updatedStart = getUpdatedDates()[0]
-      const updatedEnd = getUpdatedDates()[1]
-      const currentDates = [
-        `Current start date: ${updatedStart.format('dddd, MMMM Do YYYY')}`,
-        `Current end date: ${updatedEnd.format('dddd, MMMM Do YYYY')}`,
-      ]
-      bot.reply(message, formatLists(currentDates))
-    })
+    const updatedStart = getUpdatedDates()[0]
+    const updatedEnd = getUpdatedDates()[1]
+    const currentDates = [
+      `Current start date: ${updatedStart.format('dddd, MMMM Do YYYY')}`,
+      `Current end date: ${updatedEnd.format('dddd, MMMM Do YYYY')}`,
+    ]
+    bot.reply(message, formatLists(currentDates))
   }
 })
 
@@ -237,9 +234,9 @@ const milestoneReminder = schedule.scheduleJob({ hour: 10, minute: 0, second: 0,
   console.log('Sending out milestone reminder')
   console.log('Sending milestones if currently on a term')
   if (onTerm) {
-    getTermStartDate(currentTerm)
+    getTerm(currentTerm)
     .then(currentTerm => {
-      currentWeek = moment().diff(currentTerm, 'weeks')
+      currentWeek = moment().diff(currentTerm.startDate, 'weeks')
       if (onTerm) controller.trigger('send_milestones', [slackbotRTM, currentWeek])
     }) 
   }
@@ -262,9 +259,9 @@ const updateTermInfo = schedule.scheduleJob({ hour: 0, minute: 0, second: 0 }, (
 })
 
 controller.hears('meme', ['direct_message'], (bot, message) => {
-  getTermStartDate('spring')
-  .then(startDate => {
-    console.log('Current start date: ', startDate)
+  getTerm('spring')
+  .then(currentTerm => {
+    console.log('Current start date: ', currentTerm.startDate)
   })
 })
 

--- a/app/server.js
+++ b/app/server.js
@@ -134,15 +134,27 @@ controller.on('send_term_start_confirmation', (bot) => {
 
 controller.hears(/(update_start)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
-    updateStartDate(moment(message.text.split(' ')[1], 'MM-DD-YYYY'))
-    bot.reply(message, `Updated start date: ${getUpdatedDates()[0].format('dddd, MMMM Do YYYY')}`)
+    const parsedDate = moment(message.text.split(' ')[1], 'MM-DD-YYYY')
+    if (!parsedDate.isValid()) {
+      bot.reply(message, 'Entered an invalid date')
+    } else {
+      updateStartDate(parsedDate)
+      const updatedStartDate = getUpdatedDates()[0].format('dddd, MMMM Do YYYY')
+      bot.reply(message, `Updated start date: ${updatedStartDate}`)
+    }
   }
 })
 
 controller.hears(/(update_end)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
-    updateEndDate(moment(message.text.split(' ')[1], 'MM-DD-YYYY'))
-    bot.reply(message, `Updated end date: ${getUpdatedDates()[1].format('dddd, MMMM Do YYYY')}`)
+    const parsedDate = moment(message.text.split(' ')[1], 'MM-DD-YYYY')
+    if (!parsedDate.isValid()) {
+      bot.reply(message, 'Entered an invalid date')
+    } else {
+      updateEndDate(parsedDate)
+      const updatedEndDate = getUpdatedDates()[1].format('dddd, MMMM Do YYYY')
+      bot.reply(message, `Updated end date: ${updatedEndDate}`)
+    }
   }
 })
 

--- a/app/server.js
+++ b/app/server.js
@@ -121,31 +121,32 @@ controller.on('send_term_start_confirmation', (bot) => {
     bot.api.im.open({ user: adminUser.id }, (err1, res1) => {
       const directChannelId = res1.channel.id
       updatingDates = true
-      getConfirmDatesMessage(currentTerm)
-      .then(message => {
-        bot.say({ channel: directChannelId, text: message }, () => { })
-      })
+      // getConfirmDatesMessage(currentTerm)
+      getConfirmDatesMessage('spring')
+        .then(message => {
+          bot.say({ channel: directChannelId, text: message }, () => { })
+        })
     })
   })
 })
 
 // --------------- confirming start dates ----------------- //
 
-controller.hears('update_start', ['direct_message'], (bot, message) => {
+controller.hears(/(update_start)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
     updateStartDate(moment(message.text.split(' ')[1], 'MM-DD-YYYY'))
     bot.reply(message, `Updated start date: ${getUpdatedDates()[0].format('dddd, MMMM Do YYYY')}`)
   }
 })
 
-controller.hears('update_end', ['direct_message'], (bot, message) => {
+controller.hears(/(update_end)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
     updateEndDate(moment(message.text.split(' ')[1], 'MM-DD-YYYY'))
     bot.reply(message, `Updated end date: ${getUpdatedDates()[1].format('dddd, MMMM Do YYYY')}`)
   }
 })
 
-controller.hears('show', ['direct_message'], (bot, message) => {
+controller.hears(/(show)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
     const updatedStart = getUpdatedDates()[0]
     const updatedEnd = getUpdatedDates()[1]
@@ -157,7 +158,7 @@ controller.hears('show', ['direct_message'], (bot, message) => {
   }
 })
 
-controller.hears('abort', ['direct_message'], (bot, message) => {
+controller.hears(/(abort)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
     updatingDates = false
     bot.reply(message, 'Alright, I will check back in with you tomorrow at 10AM')
@@ -168,7 +169,7 @@ controller.hears('abort', ['direct_message'], (bot, message) => {
   }
 })
 
-controller.hears('complete', ['direct_message'], (bot, message) => {
+controller.hears(/(complete)\b/, ['direct_message'], (bot, message) => {
   if (updatingDates) {
     updatingDates = false
     confirmedDates = true
@@ -180,7 +181,7 @@ controller.hears('complete', ['direct_message'], (bot, message) => {
   }
 })
 
-controller.hears('update_term_dates', ['direct_message'], (bot, message) => {
+controller.hears(/(update_term_dates)\b/, ['direct_message'], (bot, message) => {
   if (!updatingDates) {
     controller.trigger('send_term_start_confirmation', [bot])
   }

--- a/app/server.js
+++ b/app/server.js
@@ -121,7 +121,6 @@ controller.on('send_term_start_confirmation', (bot) => {
     bot.api.im.open({ user: adminUser.id }, (err1, res1) => {
       const directChannelId = res1.channel.id
       updatingDates = true
-      // getConfirmDatesMessage(currentTerm)
       getConfirmDatesMessage(currentTerm)
         .then(message => {
           bot.say({ channel: directChannelId, text: message }, () => { })

--- a/app/server.js
+++ b/app/server.js
@@ -3,9 +3,10 @@ import schedule from 'node-schedule'
 import moment from 'moment'
 import { createUser, getDALIUsers } from './db-actions/user-actions'
 import { pokeChannels, getPokeChannels } from './data-actions/channel-productivity'
-import { getMilestone, checkOnTerm } from './data-actions/milestones'
+import { getMilestone, checkOnTerm, getTermStartDate } from './data-actions/milestones'
 
 let currentWeek = 0
+let currentTerm = null
 let onTerm = false
 
 // botkit controller
@@ -151,7 +152,7 @@ const milestoneReminder = schedule.scheduleJob({ hour: 10, minute: 0, second: 0,
 
     console.log('Sending milestones if currently on a term')
     if (onTerm) {
-      currentWeek += 1
+      currentWeek = moment().diff(getTermStartDate(currentTerm), 'weeks')
       if (onTerm) controller.trigger('send_milestones', [bot, currentWeek])
     }
     // reset the week counter
@@ -168,5 +169,7 @@ const updateTermBounds = schedule.scheduleJob({ hour: 0, minute: 0, second: 0 },
    * TODO: Check with admin to make sure that currently assigned
    * start/end dates are correct
    */
-  onTerm = checkOnTerm()
+  const termResults = checkOnTerm()
+  currentTerm = termResults.term
+  onTerm = termResults.onTerm
 })

--- a/app/server.js
+++ b/app/server.js
@@ -1,6 +1,7 @@
 import botkit from 'botkit'
 import schedule from 'node-schedule'
 import moment from 'moment'
+import * as db from './db'
 import { createUser, getDALIUsers } from './db-actions/user-actions'
 import { pokeChannels, getPokeChannels } from './data-actions/channel-productivity'
 import { checkOnTerm, getTermStartDate, daysBeforeStart, getConfirmDatesMessage, generateTermDates } from './data-actions/term-dates'
@@ -225,8 +226,12 @@ const updateTermInfo = schedule.scheduleJob({ hour: 0, minute: 0, second: 0 }, (
   onTerm = termResults.onTerm
 })
 
+controller.hears('meme', ['direct_message'], (bot, message) => {
+  console.log(getTermStartDate('spring'))
+})
+
 console.log('Sending confirmation message to user')
-controller.trigger('send_term_start_confirmation', [slackbotRTM])
+// controller.trigger('send_term_start_confirmation', [slackbotRTM])
 
 // Checks daily at 10AM to see whether the bot should update the start dates for the term
 const updateTermStart = schedule.scheduleJob({ hour: 10, minute: 0, second: 0 }, () => {


### PR DESCRIPTION
The bot interacts with an admin user, which is currently set to me.

There are five new commands that have been introduced:
**update_start** - updates the upcoming term's start date
**update_end** - updates the upcoming term's end date
**show** - shows the tentative term dates
**abort** - ends the conversation that will be picked up again tomorrow at 10 AM
**complete** - ends the conversation and finalizing term dates

